### PR TITLE
fix source and target compiler plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -141,8 +141,8 @@
 				<artifactId>maven-compiler-plugin</artifactId>
 				<version>3.6.0</version>
 				<configuration>
-					<source>1.6</source>
-					<target>1.6</target>
+					<source>1.8</source>
+					<target>1.8</target>
 					<compilerArgument>-Xlint:-options</compilerArgument>
 					<compilerArguments>
 						<endorseddirs>${endorsed.dir}</endorseddirs>


### PR DESCRIPTION
Para can not be compiled with jdk version 6. 
There is many class in project that use java 8 feature for example AzureIoTService