### PR TITLE
Implements simple health check at /v1/_health

### DIFF
--- a/para-server/src/main/java/com/erudika/para/security/RestAuthFilter.java
+++ b/para-server/src/main/java/com/erudika/para/security/RestAuthFilter.java
@@ -185,6 +185,10 @@ public class RestAuthFilter extends GenericFilterBean implements InitializingBea
 	}
 
 	private boolean hasPermission(App parentApp, User user, HttpServletRequest request) {
+		String resourcePath = RestUtils.extractResourcePath(request);
+		if ("_health".equals(resourcePath) && request.getMethod().equals(GET)) {
+			return true; // allow health checks by anyone without restrictions
+		}
 		if (parentApp == null) {
 			return false;
 		}
@@ -192,7 +196,6 @@ public class RestAuthFilter extends GenericFilterBean implements InitializingBea
 		if (user != null && user.isAdmin()) {
 			return Config.getConfigBoolean("admins_have_full_api_access", true);
 		}
-		String resourcePath = RestUtils.extractResourcePath(request);
 		if (resourcePath.matches("^_permissions/.+") && request.getMethod().equals(GET)) {
 			return true; // allow permission checks, i.e. pc.isAllowed(), to go through
 		}

--- a/para-server/src/main/java/com/erudika/para/utils/HealthUtils.java
+++ b/para-server/src/main/java/com/erudika/para/utils/HealthUtils.java
@@ -1,0 +1,57 @@
+package com.erudika.para.utils;
+
+import com.erudika.para.Para;
+import com.erudika.para.core.App;
+
+/**
+ * A utility for evaluating the health of the Para cluster.
+ * @author Jeremy Wiesner [jswiesner@gmail.com]
+ */
+public final class HealthUtils {
+
+	private static final int HEALTH_CHECK_INTERVAL_MS = 1000 * Config.getConfigInt("health.check_interval", 60);
+	private static volatile long lastHealthCheckTime = -1L;
+	private static boolean healthy = false;
+
+	private HealthUtils() { }
+
+	/**
+	 * A method to query the general health of the Para server.
+	 * @return true if server is healthy
+	 */
+	public static boolean isHealthy() {
+		if (isTimeForHealthCheck()) {
+			performHealthCheck();
+		}
+		return healthy;
+	}
+
+	/**
+	 * Evaluate the health of the Para server by querying the root app object from the database, search and cache.
+	 */
+	private static synchronized void performHealthCheck() {
+		if (isTimeForHealthCheck()) {
+			healthy = true;
+			String rootAppId = App.id(Config.getRootAppIdentifier());
+			if (rootAppId != null && !rootAppId.isEmpty()) {
+				// read the root app from the DAO
+				if (Para.getDAO() != null && Para.getDAO().read(rootAppId) == null) {
+					healthy = false;
+				}
+				// read the root app from the search, if enabled
+				if (healthy && Config.isSearchEnabled() && Para.getSearch().findById(rootAppId) == null) {
+					healthy = false;
+				}
+				// read the root app from the cache, if enabled
+				if (healthy && Config.isCacheEnabled() && !Para.getCache().contains(rootAppId)) {
+					healthy = false;
+				}
+			}
+			lastHealthCheckTime = Utils.timestamp();
+		}
+	}
+
+	private static boolean isTimeForHealthCheck() {
+		return (Utils.timestamp() - lastHealthCheckTime) > HEALTH_CHECK_INTERVAL_MS;
+	}
+}


### PR DESCRIPTION
This pull request implements a simple health check that is mapped to GET /v1/_health. This end point returns 200 "healthy" if the server is healthy, and 500 "unhealthy" if not. The health check is configured to simply read the root app object from the DAO, Search and Cache to ensure there are active connections with each resource. The implementation is done in a new class called HealthUtils in the utils package of para-server. 

The health check end point has no security on it so it can be easily called by any application or a load balancer. To prevent excessive calls to the health check end point, the health check method is only allowed to run at a fixed interval (defaults to once per minute, but can be configured using **para.health.check_interval**). If it's been more than a minute since the last health check, the first thread to call the health check method will actually perform the health check and update the server status. My feeling that a 1 minute interval is sufficient to detect issues and respond promptly without inducing unnecessary load on the system.

Now that this mechanism is in place, should the Para server call the health check internally as well? My thinking is that it would be worthwhile to call the health check once (maybe with a retry or two built-in?) at the very end of the server's initialization to make sure all of the required resources are working properly. If the health check fails, I think it's reasonable to throw a RuntimeException or IllegalStateException to indicate that the server failed to startup properly. If the DAO, Search or Cache cannot be accessed, it probably doesn't make sense to startup the Para server and expose it to traffic.

One thing I wanted to mention is that the server will respond as unhealthy the first time the Para server starts up and the root app hasn't been created yet. If we add an option to block server starting due to an unhealthy state after initialization, we should remove this block in the single case that the root app hasn't been created yet, though I'm not sure how we detect this to be the case.