### PR TITLE
Adds option to push system metrics to a Graphite server

### DIFF
--- a/para-server/pom.xml
+++ b/para-server/pom.xml
@@ -193,6 +193,11 @@
 			<artifactId>metrics-core</artifactId>
 			<version>3.2.5</version>
 		</dependency>
+		<dependency>
+			<groupId>io.dropwizard</groupId>
+			<artifactId>dropwizard-metrics-graphite</artifactId>
+			<version>1.2.2</version>
+		</dependency>
 
 		<!-- OTHER -->
 		<dependency>

--- a/para-server/src/main/java/com/erudika/para/utils/HealthUtils.java
+++ b/para-server/src/main/java/com/erudika/para/utils/HealthUtils.java
@@ -26,7 +26,7 @@ public enum HealthUtils implements InitializeListener, Runnable {
 		private boolean wasHealthy = false;
 		private ScheduledFuture<?> scheduledHealthCheck;
 		private final List<String> failedServices = new ArrayList<>(3);
-		private final int HEALTH_CHECK_INTERVAL_SECONDS = Config.getConfigInt("health.check_interval", 60);
+		private final int healthCheckInterval = Config.getConfigInt("health.check_interval", 60);
 
 		@Override
 		public boolean isHealthy() {
@@ -74,7 +74,7 @@ public enum HealthUtils implements InitializeListener, Runnable {
 			}
 			if (Config.getConfigBoolean("health_check_enabled", true) && scheduledHealthCheck == null) {
 				scheduledHealthCheck = Para.getScheduledExecutorService().
-						scheduleAtFixedRate(this, 30, HEALTH_CHECK_INTERVAL_SECONDS, TimeUnit.SECONDS);
+						scheduleAtFixedRate(this, 30, healthCheckInterval, TimeUnit.SECONDS);
 			}
 		}
 


### PR DESCRIPTION
@albogdano, this PR adds an option to push system metrics to a Graphite server. There are 4 config settings that control the behavior of metrics pushing:

- **para.metrics.graphite.host**: The URL of the host to push metrics to (defaults to **localhost**)
- **para.metrics.graphite.port**: The port number of the Graphite server (defaults to **2003**)
- **para.metrics.graphite.prefix**: The prefix for applying to metric names (defaults to **null**, an example of this would be "com.erudika")
- **para.metrics.graphite.period**: The period for how often to push system metrics in seconds (defaults to 0, which disables this option)

To test this out, I suggest running a local Graphite server:
`https://github.com/hopsoft/docker-graphite-statsd`
And then run a local Grafana server:
`http://docs.grafana.org/installation/docker/`

To run Grafana locally, here is the Docker command I was using:
`docker run -d -p 3000:3000 -e GF_SECURITY_ADMIN_USER=admin -e GF_SECURITY_ADMIN_PASSWORD=password -e GF_METRICS_GRAPHITE_ADDRESS=localhost:2003 grafana/grafana`
Then you can login using admin/password at the login screen.

For now I only implemented push of system metrics. The next step is to add the option for each application to specify its own Graphite push settings. Since we agreed that the pull metrics feature using the REST API isn't useful in a cluster, I removed this from the code. Let me know if you'd prefer to keep this and I can undo the remove. 

For app-specific metrics, where in the code do you suggest we implement validation of the Graphite settings? Do we want to enforce a lower bound on the reporting frequency for apps (i.e. is there any concern if a bunch of apps ask for push metrics at a period of 1 second)?