### PR TITLE
Adds RegistryUtils to create, read, and update registry objects.

### DIFF
--- a/para-core/src/main/java/com/erudika/para/utils/RegistryUtils.java
+++ b/para-core/src/main/java/com/erudika/para/utils/RegistryUtils.java
@@ -1,0 +1,73 @@
+package com.erudika.para.utils;
+
+import com.erudika.para.core.Sysprop;
+import com.erudika.para.core.utils.CoreUtils;
+import org.apache.commons.lang3.StringUtils;
+
+import java.util.Map;
+
+/**
+ * A utility for creating, reading, and updating registries. The Registry allows for efficient sharing of information
+ * between multiple nodes of a Para cluster. Registry objects are saved in the DAO resource for the root application.
+ * @author Jeremy Wiesner [jswiesner@gmail.com]
+ */
+public final class RegistryUtils {
+
+	private static final String REGISTRY_PREFIX = "Registry:";
+	private static final String REGISTRY_APP_ID = Config.getRootAppIdentifier();
+
+	private RegistryUtils() { }
+
+	/**
+	 * Add a specific value to a registry. If the registry doesn't exist yet, create it.
+	 * @param registryName the name of the registry.
+	 * @param key the unique key corresponding to the value to insert (typically an appid).
+	 * @param value the value to add to the registry.
+	 */
+	public static void putValue(String registryName, String key, Object value) {
+		if (StringUtils.isBlank(registryName) || StringUtils.isBlank(key) || value == null) {
+			return;
+		}
+		Sysprop registryObject = readRegistryObject(registryName);
+		if (registryObject == null) {
+			registryObject = new Sysprop(getRegistryID(registryName));
+		}
+		registryObject.addProperty(key, value);
+		CoreUtils.getInstance().getDao().create(REGISTRY_APP_ID, registryObject);
+	}
+
+	/**
+	 * Retrieve one specific value from a registry.
+	 * @param registryName the name of the registry.
+	 * @param key the unique key corresponding to the value to retrieve (typically an appid).
+	 * @return the value corresponding to the registry key, null if no value is found for the specified key.
+	 */
+	public static Object getValue(String registryName, String key) {
+		Map<String, Object> registry = getRegistry(registryName);
+		if (registry == null || StringUtils.isBlank(key)) {
+			return null;
+		}
+		return registry.get(key);
+	}
+
+	/**
+	 * Retrieve an entire registry.
+	 * @param registryName the name of the registry.
+	 * @return the map of all registry values, null if no registry is found by the specified name.
+	 */
+	public static Map<String, Object> getRegistry(String registryName) {
+		if (StringUtils.isBlank(registryName)) {
+			return null;
+		}
+		Sysprop registryObject = readRegistryObject(registryName);
+		return registryObject == null ? null : registryObject.getProperties();
+	}
+
+	private static Sysprop readRegistryObject(String registryName) {
+		return CoreUtils.getInstance().getDao().read(REGISTRY_APP_ID, getRegistryID(registryName));
+	}
+
+	private static String getRegistryID(String registryName) {
+		return REGISTRY_PREFIX + registryName;
+	}
+}

--- a/para-server/src/main/java/com/erudika/para/metrics/MetricsUtils.java
+++ b/para-server/src/main/java/com/erudika/para/metrics/MetricsUtils.java
@@ -79,8 +79,8 @@ public enum MetricsUtils implements InitializeListener {
 			if (graphitePeriod > 0) {
 				String host = Config.getConfigParam("metrics.graphite.host", "localhost");
 				int port = Config.getConfigInt("metrics.graphite.port", 2003);
-				String prefix = Config.getConfigParam("metrics.graphite.prefix", null);
-				MetricsUtils.createGraphiteReporter(SYSTEM_METRICS_NAME, host, port, prefix, graphitePeriod);
+				String prefixSystem = Config.getConfigParam("metrics.graphite.prefix_system", null);
+				MetricsUtils.createGraphiteReporter(SYSTEM_METRICS_NAME, host, port, prefixSystem, graphitePeriod);
 			}
 
 			// find all app objects even if there are more than 10000 apps in the system


### PR DESCRIPTION
@albogdano - Adds RegistryUtils class with methods to create, read and update registry objects. Registry objects are persisted to the DAO resource of the root application. The registry function is only intended for use within the Para application (it's not an intentionally exposed resource), so there are no permissions built into this.

I also moved the Graphite reporter prefix variable for the system to **para.metrics.graphite.prefix_system**. This allows for the addition of **para.metrics.graphite.prefix_apps** later.