### PR TITLE
Adds app-specific settings for pushing metrics to Graphite

### DIFF
--- a/para-core/src/main/java/com/erudika/para/AppSettingAddedListener.java
+++ b/para-core/src/main/java/com/erudika/para/AppSettingAddedListener.java
@@ -1,0 +1,37 @@
+/*
+ * Copyright 2013-2017 Erudika. https://erudika.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For issues and patches go to: https://github.com/erudika
+ */
+package com.erudika.para;
+
+import com.erudika.para.core.App;
+
+import java.util.EventListener;
+
+/**
+ * This listener is executed when a setting is added to an application.
+ * @author Jeremy Wiesner [jswiesner@gmail.com]
+ */
+public interface AppSettingAddedListener extends EventListener {
+
+	/**
+	 * Code to execute right after a setting is added (could be updated or added for the first time).
+	 * @param app the app object
+	 * @param settingKey the key of the setting to add
+	 * @param settingValue the value of the setting to add
+	 */
+	void onSettingAdded(App app, String settingKey, Object settingValue);
+}

--- a/para-core/src/main/java/com/erudika/para/AppSettingRemovedListener.java
+++ b/para-core/src/main/java/com/erudika/para/AppSettingRemovedListener.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2013-2017 Erudika. https://erudika.com
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+ * For issues and patches go to: https://github.com/erudika
+ */
+package com.erudika.para;
+
+import com.erudika.para.core.App;
+
+import java.util.EventListener;
+
+/**
+ * This listener is executed when a setting is removed from an application.
+ * @author Jeremy Wiesner [jswiesner@gmail.com]
+ */
+public interface AppSettingRemovedListener extends EventListener {
+
+	/**
+	 * Code to execute right after a setting is removed.
+	 * @param app the app object
+	 * @param settingKey the key (name) of the setting to remove
+	 */
+	void onSettingRemoved(App app, String settingKey);
+}

--- a/para-core/src/main/java/com/erudika/para/utils/RegistryUtils.java
+++ b/para-core/src/main/java/com/erudika/para/utils/RegistryUtils.java
@@ -51,6 +51,22 @@ public final class RegistryUtils {
 	}
 
 	/**
+	 * Remove a specific value from a registry.
+	 * @param registryName the name of the registry.
+	 * @param key the unique key corresponding to the value to remove (typically an appid).
+	 */
+	public static void removeValue(String registryName, String key) {
+		Sysprop registryObject = readRegistryObject(registryName);
+		if (registryObject == null || StringUtils.isBlank(key)) {
+			return;
+		}
+		if (registryObject.hasProperty(key)) {
+			registryObject.removeProperty(key);
+			CoreUtils.getInstance().getDao().create(REGISTRY_APP_ID, registryObject);
+		}
+	}
+
+	/**
 	 * Retrieve an entire registry.
 	 * @param registryName the name of the registry.
 	 * @return the map of all registry values, null if no registry is found by the specified name.

--- a/para-core/src/main/java/com/erudika/para/utils/RegistryUtils.java
+++ b/para-core/src/main/java/com/erudika/para/utils/RegistryUtils.java
@@ -31,9 +31,12 @@ public final class RegistryUtils {
 		Sysprop registryObject = readRegistryObject(registryName);
 		if (registryObject == null) {
 			registryObject = new Sysprop(getRegistryID(registryName));
+			registryObject.addProperty(key, value);
+			CoreUtils.getInstance().getDao().create(REGISTRY_APP_ID, registryObject);
+		} else {
+			registryObject.addProperty(key, value);
+			CoreUtils.getInstance().getDao().update(REGISTRY_APP_ID, registryObject);
 		}
-		registryObject.addProperty(key, value);
-		CoreUtils.getInstance().getDao().create(REGISTRY_APP_ID, registryObject);
 	}
 
 	/**
@@ -62,7 +65,7 @@ public final class RegistryUtils {
 		}
 		if (registryObject.hasProperty(key)) {
 			registryObject.removeProperty(key);
-			CoreUtils.getInstance().getDao().create(REGISTRY_APP_ID, registryObject);
+			CoreUtils.getInstance().getDao().update(REGISTRY_APP_ID, registryObject);
 		}
 	}
 

--- a/para-server/src/main/java/com/erudika/para/metrics/MetricsUtils.java
+++ b/para-server/src/main/java/com/erudika/para/metrics/MetricsUtils.java
@@ -83,9 +83,9 @@ public enum MetricsUtils implements InitializeListener, Runnable {
 			// initialize metrics for the system and all existing applications
 			MetricsUtils.initializeMetrics(SYSTEM_METRICS_NAME);
 
-			// setup graphite reporting for the system metrics
-			if (GRAPHITE_PERIOD > 0) {
-				String host = Config.getConfigParam("metrics.graphite.host", "localhost");
+			// setup graphite reporting for the system
+			String host = Config.getConfigParam("metrics.graphite.host", null);
+			if (GRAPHITE_PERIOD > 0 && !StringUtils.isBlank(host)) {
 				int port = Config.getConfigInt("metrics.graphite.port", 2003);
 				String prefixSystem = Config.getConfigParam("metrics.graphite.prefix_system", null);
 				if (INSTANCE_ID != null) {

--- a/para-server/src/main/java/com/erudika/para/metrics/MetricsUtils.java
+++ b/para-server/src/main/java/com/erudika/para/metrics/MetricsUtils.java
@@ -38,6 +38,7 @@ import com.erudika.para.utils.HealthUtils;
 import com.erudika.para.utils.RegistryUtils;
 import com.erudika.para.utils.Pager;
 import com.erudika.para.utils.Utils;
+import com.google.common.collect.Lists;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -465,6 +466,7 @@ public enum MetricsUtils implements InitializeListener, Runnable {
 						// the new settings aren't the same, stop the existing reporter and replace it with a new one
 						GRAPHITE_REPORTERS.get(appid).stop();
 						GRAPHITE_REPORTERS.remove(appid);
+						GRAPHITE_SETTINGS.remove(appid);
 						createAppGraphiteReporter(appid, settings);
 					}
 				} else {
@@ -475,10 +477,16 @@ public enum MetricsUtils implements InitializeListener, Runnable {
 			}
 			if (graphiteRegistry.size() < (GRAPHITE_REPORTERS.size() - numNewReporters)) {
 				// at least one of the graphite reporters was disabled by an app, so we need to remove it
+				List<Map.Entry<String, GraphiteReporter>> appsToRemove = Lists.newArrayList();
 				for (Map.Entry<String, GraphiteReporter> iter : GRAPHITE_REPORTERS.entrySet()) {
 					if (!graphiteRegistry.containsKey(iter.getKey())) {
-						iter.getValue().stop();
+						appsToRemove.add(iter);
 					}
+				}
+				for (Map.Entry<String, GraphiteReporter> iter : appsToRemove) {
+					iter.getValue().stop();
+					GRAPHITE_REPORTERS.remove(iter.getKey());
+					GRAPHITE_SETTINGS.remove(iter.getKey());
 				}
 			}
 		}

--- a/para-server/src/main/java/com/erudika/para/rest/Api1.java
+++ b/para-server/src/main/java/com/erudika/para/rest/Api1.java
@@ -61,6 +61,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
+import java.util.stream.Collectors;
 import javax.ws.rs.HttpMethod;
 import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.core.HttpHeaders;
@@ -650,7 +651,18 @@ public final class Api1 extends ResourceConfig {
 							if (!StringUtils.isBlank(key) && setting.containsKey("value")) {
 								app.addSetting(key, setting.get("value"));
 							} else {
-								app.setSettings(setting);
+								// remove the old settings one at a time so the remove setting listeners are invoked
+								Map<String, Object> oldSettings = app.getSettings();
+								if (oldSettings != null && !oldSettings.isEmpty()) {
+									List<String> keysToRemove = oldSettings.keySet().stream().collect(Collectors.toList());
+									keysToRemove.stream().forEach(oldKey -> app.removeSetting(oldKey));
+								}
+								// add the new settings one at a time so the add setting listeners are invoked
+								if (setting != null) {
+									for (Map.Entry<String, Object> iter : setting.entrySet()) {
+										app.addSetting(iter.getKey(), iter.getValue());
+									}
+								}
 							}
 							app.update();
 							return Response.ok().build();


### PR DESCRIPTION
This PR adds app-specific settings for pushing metrics to Graphite. Each app can register it's own Graphite server where it wants it's own metrics pushed. The MetricsUtils class will create a GraphiteReporter for each app that registers this setting.

To allow for app-specific pushing to Graphite, it first must be enabled by the Para server. There are a total of 5 Graphite settings that are configurable by the Para server:

- **para.metrics.graphite.period** (default: 0)
- **para.metrics.graphite.host** (default: null)
- **para.metrics.graphite.port** (default: 2003)
- **para.metrics.graphite.prefix_system** (default: null)
- **para.metrics.graphite.prefix_apps** (default: null)

The variable **para.metrics.graphite.period** controls how often (in seconds) metrics data is pushed to the Graphite server. This field controls the frequency of metrics reporting for both the system-wide metrics as well as any app-specific metrics that are pushed to Graphite. The default value is zero, which disables all push to Graphite. Settings this value to a positive number (i.e. 60) will allow for system metrics to be pushed to a Graphite server, as well as application metrics. 

System-wide metrics are only reported to a Graphite server if **para.metrics.graphite.host** is not blank (it defaults to null). This field specifies the host of the Graphite server to push only system metrics to. **para.metrics.graphite.port** is the corresponding port number to the host (usually 2003 for Graphite). 

Graphite metrics are often prefixed by some path to distinguish application metrics from other applications pushing to the same Graphite server. For example, you may want to prefix your Para application metrics with "com.erudika.para". There are two fields for configuring a prefix for pushing metrics to Graphite. First, **para.metrics.graphite.prefix_apps** indicates the prefix that should be applied when pushing the system-wide metrics. Second, **para.metrics.graphite.prefix_apps** indicates the template prefix that should be applied when pushing a specific application's metrics to Graphite.

It's common practice in a distributed environment to include the instance ID in the prefix for pushing metrics data. That makes it possible to view metrics for each node in your cluster, and perform an aggregation across all nodes. This is supported by defining the instance ID for your system in an environment variable called **para.instance_id**. If you define **para.instance_id**, you can reference it in the **para.metrics.graphite.prefix_system** and **para.metrics.graphite.prefix_apps** variables. To include the instance ID, simply add **{{INSTANCE_ID}}** in your prefix variables and Para will replace it with the contents of **para.instance_id**. For example, a system prefix variable may be configured as follows in your application config file.

`para.instance_id=1234abcd`
`para.metrics.graphite.prefix_system="com.erudika.para.{{INSTANCE_ID}}.system"`

**para.metrics.graphite.prefix_apps** supports both the **{{INSTANCE_ID}}** field as well as the application's identifier using **{{APP_ID}}**. This allows application-specific metrics to contain the application's ID in the prefix path. For example, an application prefix variable may be configured as follows in your application config file.

`para.metrics.graphite.prefix_apps="com.erudika.para.{{INSTANCE_ID}}.{{APP_ID}}"`

Configuring the Graphite host settings for a specific application can be done by adding a setting to the application. Para will look for an application setting by the name "metricsGraphiteReporter" to detect application-specific Graphite settings. This setting is configured in the form of a map with two fields: **"host"** (String) and **"port"** (int). For example, to add application-specific metrics make a signed request to Para as follows:

```
PUT /v1/_settings/metricsGraphiteReporter
{
    "value": {
        "host":"localhost",
        "port":2003
    }
}
```

Two new listeners are added in this PR: AppSettingAddedListener and AppSettingRemovedListener. MetricsUtils registers added/removed listeners to detect settings added or removed by the name "metricsGraphiteReporter". When an application adds or updates this setting, MetricsUtils will persist the updated host and port values to a registry that holds all application-specific Graphite settings. A scheduled execution of MetricsUtils#syncAppMetricsReporters() occurs once per minute to read the Graphite settings registry and detect changes. If a new app setting is detected, a new GraphiteReporter is created. If an app updates its settings, the old GraphiteReporter is closed and a new one is opened. If an app deleted its settings, the GraphiteReporter is simply closed.

@albogdano One thing I noticed when testing this feature was not all metrics were pushed to the Graphite server. When metrics data started showing up in my Graphite server, I was seeing maybe 5-10% of all the metrics that are captured in the system. As soon as Para starts pushing metrics data, the Graphite server should see all possible metrics, even if they contain all zeros. In my testing, over time eventually all the metrics would show up in Graphite (maybe 10-20 minutes later). I've never seen this before, and I'm not sure if it's an issue with the GraphiteReporter from Para's end, or if it's an issue with my local Graphite server. What is your experience with this so far?