### PR TITLE
Fixes bug in SearchQueryAspect when AOP is applied to non-public methods

### DIFF
--- a/para-server/src/main/java/com/erudika/para/aop/IndexAndCacheAspect.java
+++ b/para-server/src/main/java/com/erudika/para/aop/IndexAndCacheAspect.java
@@ -113,7 +113,7 @@ public class IndexAndCacheAspect implements MethodInterceptor {
 			superMethod = DAO.class.getMethod(daoMethod.getName(), daoMethod.getParameterTypes());
 			indexedAnno = Config.isSearchEnabled() ? superMethod.getAnnotation(Indexed.class) : null;
 			cachedAnno = Config.isCacheEnabled() ? superMethod.getAnnotation(Cached.class) : null;
-			detectNestedInvocations(mi);
+			detectNestedInvocations(daoMethod);
 		} catch (Exception e) {
 			logger.error("Error in AOP layer!", e);
 		}
@@ -380,10 +380,9 @@ public class IndexAndCacheAspect implements MethodInterceptor {
 	/**
 	 * Try and detect if a DAO method is called from another public DAO method, annotated with {@link Indexed} or
 	 * {@link Cached}. It causes that method to be intercepted twice and objects will be indexed/cached twice.
-	 * @param mi method invocation
+	 * @param daoMethod invoked dao method
 	 */
-	private void detectNestedInvocations(MethodInvocation mi) {
-		Method daoMethod = mi.getMethod();
+	private void detectNestedInvocations(Method daoMethod) {
 		if (!daoMethod.getName().startsWith("read")) {
 			StackTraceElement[] stackTraceElements = Thread.currentThread().getStackTrace();
 			for (StackTraceElement stackTraceElement : stackTraceElements) {

--- a/para-server/src/main/java/com/erudika/para/aop/IndexAndCacheAspect.java
+++ b/para-server/src/main/java/com/erudika/para/aop/IndexAndCacheAspect.java
@@ -97,7 +97,6 @@ public class IndexAndCacheAspect implements MethodInterceptor {
 	 * @throws Throwable error
 	 */
 	public Object invoke(MethodInvocation mi) throws Throwable {
-		detectNestedInvocations(mi);
 		if (!Modifier.isPublic(mi.getMethod().getModifiers())) {
 			return mi.proceed();
 		}
@@ -114,6 +113,7 @@ public class IndexAndCacheAspect implements MethodInterceptor {
 			superMethod = DAO.class.getMethod(daoMethod.getName(), daoMethod.getParameterTypes());
 			indexedAnno = Config.isSearchEnabled() ? superMethod.getAnnotation(Indexed.class) : null;
 			cachedAnno = Config.isCacheEnabled() ? superMethod.getAnnotation(Cached.class) : null;
+			detectNestedInvocations(mi);
 		} catch (Exception e) {
 			logger.error("Error in AOP layer!", e);
 		}

--- a/para-server/src/main/java/com/erudika/para/aop/SearchQueryAspect.java
+++ b/para-server/src/main/java/com/erudika/para/aop/SearchQueryAspect.java
@@ -24,6 +24,7 @@ import com.erudika.para.metrics.MetricsUtils;
 import static com.erudika.para.metrics.MetricsUtils.time;
 import com.erudika.para.search.Search;
 import java.lang.reflect.Method;
+import java.lang.reflect.Modifier;
 import java.util.List;
 import org.aopalliance.intercept.MethodInterceptor;
 import org.aopalliance.intercept.MethodInvocation;
@@ -48,6 +49,10 @@ public class SearchQueryAspect implements MethodInterceptor {
 	 * @throws Throwable error
 	 */
 	public Object invoke(MethodInvocation mi) throws Throwable {
+		if (!Modifier.isPublic(mi.getMethod().getModifiers())) {
+			return mi.proceed();
+		}
+
 		Method searchMethod = mi.getMethod();
 		Object[] args = mi.getArguments();
 		String appid = AOPUtils.getFirstArgOfString(args);


### PR DESCRIPTION
Also fixes IndexAndCacheAspect so that when the method is not public it simply calls mi.proceed(), as opposed to invokeDao() which will time the mi.proceed() call. In this case we only want to call invokeDao() and initiate a Timer when the method is public.