### PR TITLE
Work around resolution to authenticate when an AD(Active Directory) doesn't have email attribute.

### DIFF
--- a/para-server/src/main/java/com/erudika/para/security/filters/LdapAuthFilter.java
+++ b/para-server/src/main/java/com/erudika/para/security/filters/LdapAuthFilter.java
@@ -112,10 +112,16 @@ public class LdapAuthFilter extends AbstractAuthenticationProcessingFilter {
 			String ldapAccountId = profile.getUsername();
 			String email = profile.getMail();
 			String name = StringUtils.join(profile.getCn(), ", ");
+			String adDomain = (String) app.getSetting("security.ldap.active_directory_domain");
 
 			if (StringUtils.isBlank(email)) {
-				LOG.warn("Failed to create LDAP user '{}' with blank email.", ldapAccountId);
-				return null;
+				if (!StringUtils.isBlank(adDomain)) {
+					LOG.warn("The AD doesn't have email attribute. Instead, it uses domain name for email address: {}@{}.", ldapAccountId, adDomain);
+					email = ldapAccountId.concat("@").concat(adDomain);
+				} else {
+					LOG.warn("Failed to create LDAP user '{}' with blank email.", ldapAccountId);
+					return null;
+				}
 			}
 
 			user.setAppid(getAppid(app));


### PR DESCRIPTION
Dear Erudika,

Please take a look at this pull request.

**Have you read the [docs](https://paraio.org/docs) first?**
Yes.

**OK, describe you changes:**
There is a case that an active directory doesn't have any email attribute.
Para doesn't allow creating an account in that case.
My opinion is it would be better to use an arbitrary value as an email address instead of denying authentication. That's because it won't be possible to integrate with Para if the AD server has this problem.
So, I chose email address like ldapAccountId@ADDomainName.

**Tests?**
Yes.

Thank you.