### PR TITLE
Adds overloaded batch CRUD methods to submit the request in chunks

### DIFF
--- a/para-client/src/main/java/com/erudika/para/client/ParaClient.java
+++ b/para-client/src/main/java/com/erudika/para/client/ParaClient.java
@@ -561,6 +561,9 @@ public final class ParaClient {
 		if (objects == null || objects.isEmpty() || objects.get(0) == null) {
 			return Collections.emptyList();
 		}
+		if (chunkSize <= 0) {
+			return createAll(objects);
+		}
 		return IntStream.range(0, (objects.size() + chunkSize - 1) / chunkSize)
 				.mapToObj(i -> objects.subList(i * chunkSize, Math.min((i + 1) * chunkSize, objects.size())))
 				.map(this::<P>createAll)
@@ -578,6 +581,9 @@ public final class ParaClient {
 	public <P extends ParaObject> List<P> readAll(List<String> keys, int chunkSize) {
 		if (keys == null || keys.isEmpty()) {
 			return Collections.emptyList();
+		}
+		if (chunkSize <= 0) {
+			return readAll(keys);
 		}
 		return IntStream.range(0, (keys.size() + chunkSize - 1) / chunkSize)
 				.mapToObj(i -> keys.subList(i * chunkSize, Math.min((i + 1) * chunkSize, keys.size())))
@@ -597,6 +603,9 @@ public final class ParaClient {
 		if (objects == null || objects.isEmpty()) {
 			return Collections.emptyList();
 		}
+		if (chunkSize <= 0) {
+			return updateAll(objects);
+		}
 		return IntStream.range(0, (objects.size() + chunkSize - 1) / chunkSize)
 				.mapToObj(i -> objects.subList(i * chunkSize, Math.min((i + 1) * chunkSize, objects.size())))
 				.map(this::<P>updateAll)
@@ -611,6 +620,10 @@ public final class ParaClient {
 	 */
 	public void deleteAll(List<String> keys, int chunkSize) {
 		if (keys == null || keys.isEmpty()) {
+			return;
+		}
+		if (chunkSize <= 0) {
+			deleteAll(keys);
 			return;
 		}
 		IntStream.range(0, (keys.size() + chunkSize - 1) / chunkSize)

--- a/para-client/src/main/java/com/erudika/para/client/ParaClient.java
+++ b/para-client/src/main/java/com/erudika/para/client/ParaClient.java
@@ -551,70 +551,70 @@ public final class ParaClient {
 	}
 
 	/**
-	 * Saves multiple objects to the data store in batches.
+	 * Saves multiple objects to the data store in chunks.
 	 * @param <P> the type of object
 	 * @param objects the list of objects to save
-	 * @param batchSize the number of objects in each batch
+	 * @param chunkSize the number of objects in each chunk
 	 * @return a list of all returned objects
 	 */
-	public <P extends ParaObject> List<P> createAll(List<P> objects, int batchSize) {
+	public <P extends ParaObject> List<P> createAll(List<P> objects, int chunkSize) {
 		if (objects == null || objects.isEmpty() || objects.get(0) == null) {
 			return Collections.emptyList();
 		}
-		return IntStream.range(0, (objects.size() + batchSize - 1) / batchSize)
-				.mapToObj(i -> objects.subList(i * batchSize, Math.min((i + 1) * batchSize, objects.size())))
+		return IntStream.range(0, (objects.size() + chunkSize - 1) / chunkSize)
+				.mapToObj(i -> objects.subList(i * chunkSize, Math.min((i + 1) * chunkSize, objects.size())))
 				.map(this::<P>createAll)
 				.flatMap(List::stream)
 				.collect(Collectors.toList());
 	}
 
 	/**
-	 * Retrieves multiple objects from the data store in batches.
+	 * Retrieves multiple objects from the data store in chunks.
 	 * @param <P> the type of object
 	 * @param keys a list of object ids
-	 * @param batchSize the number of objects in each batch
+	 * @param chunkSize the number of objects in each chunk
 	 * @return a list of all objects
 	 */
-	public <P extends ParaObject> List<P> readAll(List<String> keys, int batchSize) {
+	public <P extends ParaObject> List<P> readAll(List<String> keys, int chunkSize) {
 		if (keys == null || keys.isEmpty()) {
 			return Collections.emptyList();
 		}
-		return IntStream.range(0, (keys.size() + batchSize - 1) / batchSize)
-				.mapToObj(i -> keys.subList(i * batchSize, Math.min((i + 1) * batchSize, keys.size())))
+		return IntStream.range(0, (keys.size() + chunkSize - 1) / chunkSize)
+				.mapToObj(i -> keys.subList(i * chunkSize, Math.min((i + 1) * chunkSize, keys.size())))
 				.map(this::<P>readAll)
 				.flatMap(List::stream)
 				.collect(Collectors.toList());
 	}
 
 	/**
-	 * Updates multiple objects in batches.
+	 * Updates multiple objects in chunks.
 	 * @param <P> the type of object
 	 * @param objects the objects to update
-	 * @param batchSize the number of objects in each batch
+	 * @param chunkSize the number of objects in each chunk
 	 * @return a list of all objects
 	 */
-	public <P extends ParaObject> List<P> updateAll(List<P> objects, int batchSize) {
+	public <P extends ParaObject> List<P> updateAll(List<P> objects, int chunkSize) {
 		if (objects == null || objects.isEmpty()) {
 			return Collections.emptyList();
 		}
-		return IntStream.range(0, (objects.size() + batchSize - 1) / batchSize)
-				.mapToObj(i -> objects.subList(i * batchSize, Math.min((i + 1) * batchSize, objects.size())))
+		return IntStream.range(0, (objects.size() + chunkSize - 1) / chunkSize)
+				.mapToObj(i -> objects.subList(i * chunkSize, Math.min((i + 1) * chunkSize, objects.size())))
 				.map(this::<P>updateAll)
 				.flatMap(List::stream)
 				.collect(Collectors.toList());
 	}
 
 	/**
-	 * Deletes multiple objects in batches.
+	 * Deletes multiple objects in chunks.
 	 * @param keys the ids of the objects to delete
-	 * @param batchSize the number of objects in each batch
+	 * @param chunkSize the number of objects in each chunk
 	 */
-	public void deleteAll(List<String> keys, int batchSize) {
+	public void deleteAll(List<String> keys, int chunkSize) {
 		if (keys == null || keys.isEmpty()) {
 			return;
 		}
-		IntStream.range(0, (keys.size() + batchSize - 1) / batchSize)
-				.mapToObj(i -> keys.subList(i * batchSize, Math.min((i + 1) * batchSize, keys.size())))
+		IntStream.range(0, (keys.size() + chunkSize - 1) / chunkSize)
+				.mapToObj(i -> keys.subList(i * chunkSize, Math.min((i + 1) * chunkSize, keys.size())))
 				.forEach(this::deleteAll);
 	}
 


### PR DESCRIPTION
I found myself often writing code to work with ParaClient's batching CRUD operations to execute large batches in smaller chunks (i.e. a chunk size of 100 or 500). If I want to call paraClient.createAll() with 10,000 objects, for example, it may have undesirable effects downstream on my database or search index to push so many objects through all at once. There's also concerns that such a large request may timeout before receiving a response from Para Server. 

I find that a safer approach is to chunk the large batches into smaller sizes. This PR adds overloaded batch CRUD methods to specify a chunk size to partition the input list and make chunked requests to Para Server. Please feel free to take it or leave it, I understand you may a different view that this feature may not be in line with your intent for ParaClient, but wanted to throw this idea out there nonetheless.
