### PR TITLE
Convert email to lower case for Gravatar hashing

### DIFF
--- a/para-core/src/main/java/com/erudika/para/core/User.java
+++ b/para-core/src/main/java/com/erudika/para/core/User.java
@@ -729,7 +729,7 @@ public class User implements ParaObject {
 	private void setGravatarPicture() {
 		if (StringUtils.isBlank(picture)) {
 			if (email != null) {
-				String emailHash = Utils.md5(email);
+				String emailHash = Utils.md5(email.toLowerCase());
 				setPicture("https://www.gravatar.com/avatar/" + emailHash + "?size=400&d=mm&r=pg");
 			} else {
 				setPicture("https://www.gravatar.com/avatar?d=mm&size=400");


### PR DESCRIPTION
Gravatar stores emails in lower case while para does not.
`MD5("first.last@email.com")` is not the same as `MD5("First.Last@email.com")`. A simple fix is to convert email to lower case before hashing it.
