### PR TITLE
Exclude unused dependencies in para-core

### DIFF
--- a/para-core/pom.xml
+++ b/para-core/pom.xml
@@ -218,6 +218,12 @@
 			<groupId>com.vladsch.flexmark</groupId>
 			<artifactId>flexmark-ext-emoji</artifactId>
 			<version>${flexmarkVer}</version>
+			<exclusions>
+				<exclusion>
+					<groupId>com.vladsch.flexmark</groupId>
+					<artifactId>flexmark-jira-converter</artifactId>
+				</exclusion>
+			</exclusions>
 		</dependency>
 		<dependency>
 			<groupId>com.vladsch.flexmark</groupId>


### PR DESCRIPTION
Hello, I'm making this PR because I noticed that dependency `flexmark-jira-converter` is a transitive dependency of module `para-core` (induced via `flexmark-ext-emoji`). However, this transitive dependency is not used, and hence it can be removed safely to make the core library slimmer, the dependency tree smaller, and the `pom` clearer.

Indeed, if we look at the Maven dependency tree of `para-core`,  we can notice that this dependency also have many dependencie that are either duplicated (and hence omitted by Maven) or unused, so with this small change we will get rid of a lot of dependency bloat:

```
 +- com.vladsch.flexmark:flexmark-ext-emoji:jar:0.50.32:compile
 |  +- (com.vladsch.flexmark:flexmark-util:jar:0.50.32:compile - omitted for duplicate)
 |  +- (com.vladsch.flexmark:flexmark:jar:0.50.32:compile - omitted for duplicate)
 |  +- com.vladsch.flexmark:flexmark-jira-converter:jar:0.50.32:compile
 |  |  +- (com.vladsch.flexmark:flexmark-util:jar:0.50.32:compile - omitted for duplicate)
 |  |  +- (com.vladsch.flexmark:flexmark-ext-gfm-strikethrough:jar:0.50.32:compile - omitted for duplicate)
 |  |  +- (com.vladsch.flexmark:flexmark-ext-tables:jar:0.50.32:compile - omitted for duplicate)
 |  |  +- com.vladsch.flexmark:flexmark-ext-wikilink:jar:0.50.32:compile
 |  |  |  +- (com.vladsch.flexmark:flexmark-util:jar:0.50.32:compile - omitted for duplicate)
 |  |  |  +- (com.vladsch.flexmark:flexmark:jar:0.50.32:compile - omitted for duplicate)
 |  |  |  \- (com.vladsch.flexmark:flexmark-formatter:jar:0.50.32:compile - omitted for duplicate)
 |  |  +- com.vladsch.flexmark:flexmark-ext-ins:jar:0.50.32:compile
 |  |  |  +- (com.vladsch.flexmark:flexmark-util:jar:0.50.32:compile - omitted for duplicate)
 |  |  |  +- (com.vladsch.flexmark:flexmark:jar:0.50.32:compile - omitted for duplicate)
 |  |  |  \- (com.vladsch.flexmark:flexmark-formatter:jar:0.50.32:compile - omitted for duplicate)
 |  |  +- com.vladsch.flexmark:flexmark-ext-superscript:jar:0.50.32:compile
 |  |  |  +- (com.vladsch.flexmark:flexmark-util:jar:0.50.32:compile - omitted for duplicate)
 |  |  |  +- (com.vladsch.flexmark:flexmark:jar:0.50.32:compile - omitted for duplicate)
 |  |  |  \- (com.vladsch.flexmark:flexmark-formatter:jar:0.50.32:compile - omitted for duplicate)
 |  |  \- (com.vladsch.flexmark:flexmark:jar:0.50.32:compile - omitted for duplicate)
```
Therefore, I'm proposing the exclusion of dependency `flexmark-jira-converter` in module `para-core`.