### PR TITLE
Add app key

### DIFF
--- a/para-core/src/main/java/com/erudika/para/utils/Config.java
+++ b/para-core/src/main/java/com/erudika/para/utils/Config.java
@@ -432,6 +432,7 @@ public final class Config {
 	 * @return The name of the default application without any spaces.
 	 */
 	public static String getRootAppIdentifier() {
-		return Utils.noSpaces(Utils.stripAndTrim(Config.getConfigParam("app_name", PARA).replaceAll("app:", ""), " "), "-");
+		String id = Config.getConfigParam("app_key", Config.getConfigParam("app_name", PARA));
+		return Utils.noSpaces(Utils.stripAndTrim(id.replaceAll("app:", ""), " "), "-");
 	}
 }


### PR DESCRIPTION
Currently, the api key is calculated from `app_name`, and is used in the cookie name for example.  
The problem is that app_name is also used to display the name of the site in the mail, the web site...

If I use for example :
`para.app_name=La communauté`.

The cookie name is invalid because `é` is rejected.

I propose to separate these 2 concepts and add `app_key`.  
My PR uses `app_name` if `app_key` does not exist for backwards compatibility.


