### PR TITLE
Don't strip username domain if AD domain is not provided

### DIFF
--- a/para-core/src/main/java/com/erudika/para/core/utils/ParaConfig.java
+++ b/para-core/src/main/java/com/erudika/para/core/utils/ParaConfig.java
@@ -942,6 +942,7 @@ public class ParaConfig extends Config {
 		if (app != null) {
 			ldapSettings.put("security.ldap.server_url", "ldap://localhost:8389/");
 			ldapSettings.put("security.ldap.active_directory_domain", "");
+			ldapSettings.put("security.ldap.ad_mode_enabled", "");
 			ldapSettings.put("security.ldap.base_dn", "dc=springframework,dc=org");
 			ldapSettings.put("security.ldap.bind_dn", "");
 			ldapSettings.put("security.ldap.bind_pass", "");

--- a/para-server/src/main/java/com/erudika/para/server/security/LDAPAuthenticationProvider.java
+++ b/para-server/src/main/java/com/erudika/para/server/security/LDAPAuthenticationProvider.java
@@ -51,9 +51,15 @@ public class LDAPAuthenticationProvider implements AuthenticationProvider {
 				String ldapServerURL = ldapSettings.get("security.ldap.server_url");
 				String searchFilter = ldapSettings.get("security.ldap.user_search_filter");
 				AbstractLdapAuthenticationProvider ldapProvider;
-				if ("true".equals(adEnabled) || !StringUtils.isBlank(adDomain)) {
+				if (adEnabled.equals("true") || !StringUtils.isBlank(adDomain)) {
+					// check if the ad domain is provided, if not don't strip the domain from the auth username
+					String upn = auth.getName();
+					if (!adDomain.isEmpty()) {
+						upn = StringUtils.substringBefore(upn, "@");
+					}
+
 					// Fix for https://github.com/Erudika/scoold/issues/67
-					authentication = new LDAPAuthentication(StringUtils.substringBefore(auth.getName(), "@"), auth.getCredentials());
+					authentication = new LDAPAuthentication(upn, auth.getCredentials());
 					String rootDn = ldapSettings.get("security.ldap.base_dn");
 					ldapProvider = StringUtils.isBlank(rootDn)
 							? new ActiveDirectoryLdapAuthenticationProvider(adDomain, ldapServerURL)


### PR DESCRIPTION
This fixes #141 by checking if the AD domain is empty before stripping it off from the username

