### PR TITLE
Add one click deploy to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,10 @@ free developer account. Browse and manage your users and objects, do backups and
 the web console. By upgrading to a premium account you will be able to scale you projects up and down in seconds and
 manage multiple apps.
 
+You can also deploy a self-hosted version in one-click with [Dome](https://app.trydome.io/signup?package=para):
+
+[![Deploy to Dome](https://trydome.io/button.svg)](https://app.trydome.io/signup?package=para)
+
 ## Quick Start
 
 1. [Download the latest executable JAR](https://github.com/Erudika/para/releases)


### PR DESCRIPTION
Hey!

We built this one-click deploy link for your users who may not know how to stand up their own infrastructure to easily self-host this.

After deployment, users receive a link like this, which can then be CNAME-ed to any domain:

https://para-1329.dome.tools

Take it for a test run—we're eager to receive your feedback! We're more than willing to maintain this for the long haul, if this is valuable for your users.