### PR TITLE
support for ldap servers requiring authentication for read access

### DIFF
--- a/para-server/src/main/java/com/erudika/para/server/security/LDAPAuthenticator.java
+++ b/para-server/src/main/java/com/erudika/para/server/security/LDAPAuthenticator.java
@@ -72,6 +72,9 @@ public final class LDAPAuthenticator implements LdapAuthenticator {
 				// this is usually not required for authentication - leave blank
 				contextSource.setPassword(bindPass);
 			}
+
+			contextSource.afterPropertiesSet();
+
 			LdapUserSearch userSearch = new FilterBasedLdapUserSearch(userSearchBase, userSearchFilter, contextSource);
 
 			if (usePasswordComparison) {


### PR DESCRIPTION
**Have you read the [docs](https://paraio.org/docs) first?**
Yes
**OK, describe you changes:**
One line changer to cause Spring Security to trigger required config generation for LDAP Servers that require authentication.

Per Spring Docs, calling this method is required when implementations are outside of the Spring Context (which LDAPAuthenticator is):  https://github.com/spring-projects/spring-ldap/blob/main/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java#L60-L62

Method call for reference:  https://github.com/spring-projects/spring-ldap/blob/main/core/src/main/java/org/springframework/ldap/core/support/AbstractContextSource.java#L409

**Tests?**
Didn't add any since it's a one liner and would require a lot of setup for an in-memory secure ldap server
