### PR TITLE
use afterPropertiesSet to initialize authenticationSource

### DIFF
--- a/para-server/src/main/java/com/erudika/para/server/security/LDAPAuthenticator.java
+++ b/para-server/src/main/java/com/erudika/para/server/security/LDAPAuthenticator.java
@@ -62,7 +62,6 @@ public final class LDAPAuthenticator implements LdapAuthenticator {
 
 			DefaultSpringSecurityContextSource contextSource =
 					new DefaultSpringSecurityContextSource(Arrays.asList(serverUrl), baseDN);
-			contextSource.setAuthenticationSource(new SpringSecurityAuthenticationSource());
 			contextSource.setCacheEnvironmentProperties(false);
 			if (!bindDN.isEmpty()) {
 				// this is usually not required for authentication - leave blank


### PR DESCRIPTION
**Have you read the [docs](https://paraio.org/docs) first?**

**OK, describe you changes:**
@albogdano  1000 apologies.  

When you call `contextSource.afterPropertiesSet()`, it will not have any affect unless the `contextSource.authenticationSource` is `null`.  I've removed the line that initializes the `authenticationSource` to the empty `SpringSecurityAuthenticationSource()`

**Tests?**
Tested this via debugging and set the `authenticationSource` to `null` manually.  LDAP Login worked correctly
