### PR TITLE
Bump and rename sslcontext-kicktart to ayza

### DIFF
--- a/para-core/pom.xml
+++ b/para-core/pom.xml
@@ -266,8 +266,8 @@
 		</dependency>
 		<dependency>
 			<groupId>io.github.hakky54</groupId>
-			<artifactId>sslcontext-kickstart</artifactId>
-			<version>9.1.0</version>
+			<artifactId>ayza</artifactId>
+			<version>10.0.0</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
The library has been renamed from sslcontext-kickstart to ayza. The latest version is 10.0.0

Sorry for the inconvenience